### PR TITLE
🚧 Fix I18n localesPaths vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.formatOnPaste": false,
   "editor.formatOnSave": false,
   "eslint.useFlatConfig": true,
-  "i18n-ally.localesPaths": ["lang"],
+  "i18n-ally.localesPaths": [ "i18n/locales" ],
   "i18n-ally.displayLanguage": "fr-FR",
   "i18n-ally.sourceLanguage": "fr",
   "i18n-ally.keystyle": "nested"


### PR DESCRIPTION
Since the version 9.X of @nuxtjs/i18n, the path has been updated.